### PR TITLE
add option to init with proxyCAS method

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -107,7 +107,7 @@ class SettingsController extends Controller
     public function saveSettings($cas_server_version, $cas_server_hostname, $cas_server_port, $cas_server_path, $cas_protected_groups, $cas_default_group,
                                  $cas_email_mapping, $cas_displayName_mapping, $cas_group_mapping, $cas_cert_path, $cas_debug_file, $cas_php_cas_path, $cas_service_url, $cas_handlelogout_servers,
                                  $cas_access_allow_groups, $cas_ecas_accepted_strengths, $cas_ecas_retrieve_groups, $cas_ecas_assurance_level, $cas_access_group_quotas, $cas_force_login_exceptions,
-                                 $cas_ecas_attributeparserenabled = NULL, $cas_ecas_request_full_userdetails = NULL, $cas_force_login = NULL, $cas_autocreate = NULL, $cas_update_user_data = NULL, $cas_link_to_ldap_backend = NULL, $cas_disable_logout = NULL)
+                                 $cas_ecas_attributeparserenabled = NULL, $cas_ecas_request_full_userdetails = NULL, $cas_force_login = NULL, $cas_autocreate = NULL, $cas_update_user_data = NULL, $cas_link_to_ldap_backend = NULL, $cas_disable_logout = NULL, $cas_use_proxy = NULL)
     {
 
         try {
@@ -146,6 +146,7 @@ class SettingsController extends Controller
             $this->config->setAppValue($this->appName, 'cas_disable_logout', ($cas_disable_logout !== NULL) ? '1' : '0');
             $this->config->setAppValue($this->appName, 'cas_ecas_attributeparserenabled', ($cas_ecas_attributeparserenabled !== NULL) ? '1' : '0');
             $this->config->setAppValue($this->appName, 'cas_ecas_request_full_userdetails', ($cas_ecas_request_full_userdetails !== NULL) ? '1' : '0');
+            $this->config->setAppValue($this->appName, 'cas_use_proxy', ($cas_use_proxy !== NULL) ? '1' : '0');
 
 
             return array(

--- a/lib/Panels/Admin.php
+++ b/lib/Panels/Admin.php
@@ -46,7 +46,7 @@ class Admin implements ISettings
     private $params = array('cas_server_version', 'cas_server_hostname', 'cas_server_port', 'cas_server_path', 'cas_force_login', 'cas_force_login_exceptions','cas_autocreate',
         'cas_update_user_data', 'cas_protected_groups', 'cas_default_group', 'cas_ecas_attributeparserenabled', 'cas_email_mapping', 'cas_displayName_mapping', 'cas_group_mapping',
         'cas_cert_path', 'cas_debug_file', 'cas_php_cas_path', 'cas_link_to_ldap_backend', 'cas_disable_logout', 'cas_handlelogout_servers', 'cas_service_url', 'cas_access_allow_groups',
-        'cas_access_group_quotas', 'cas_ecas_accepted_strengths', 'cas_ecas_retrieve_groups','cas_ecas_request_full_userdetails', 'cas_ecas_assurance_level');
+        'cas_access_group_quotas', 'cas_ecas_accepted_strengths', 'cas_ecas_retrieve_groups','cas_ecas_request_full_userdetails', 'cas_ecas_assurance_level','cas_use_proxy');
 
     /**
      * @var IConfig

--- a/lib/Service/AppService.php
+++ b/lib/Service/AppService.php
@@ -153,6 +153,11 @@ class AppService
     private $ecasAttributeParserEnabled;
 
     /**
+     * @var boolean
+     */
+    private $casUseProxy;
+
+    /**
      * UserService constructor.
      * @param $appName
      * @param \OCP\IConfig $config
@@ -190,6 +195,7 @@ class AppService
         $this->casPath = $this->config->getAppValue('user_cas', 'cas_server_path', '/cas');
         $this->casServiceUrl = $this->config->getAppValue('user_cas', 'cas_service_url', '');
         $this->casCertPath = $this->config->getAppValue('user_cas', 'cas_cert_path', '');
+        $this->casUseProxy = $this->config->getAppValue('user_cas', 'cas_use_proxy', '');
 
         $this->casDisableLogout = boolval($this->config->getAppValue($this->appName, 'cas_disable_logout', false));
         $logoutServersArray = explode(",", $this->config->getAppValue('user_cas', 'cas_handlelogout_servers', ''));
@@ -261,7 +267,10 @@ class AppService
 
 
                 # Initialize client
-                \phpCAS::client($this->casVersion, $this->casHostname, intval($this->casPort), $this->casPath);
+                if($this->casUseProxy)
+                    \phpCAS::proxy($this->casVersion, $this->casHostname, intval($this->casPort), $this->casPath);
+                else
+                    \phpCAS::client($this->casVersion, $this->casHostname, intval($this->casPort), $this->casPath);
 
                 # Handle logout servers
                 if (!$this->casDisableLogout && count($this->casHandleLogoutServers) > 0) {


### PR DESCRIPTION
In my case i need a proxy init for make a ftpcas after.
I'm added a option in admin panel to check or not the proxyCAS init = use_proxy_cas
And i'm tested the option to make a phpcas::client or a phpcas::proxy in AppService.php

By default use_proxy_cas is flase