### PR TITLE
Bug fix : ConnectMobileApp

### DIFF
--- a/lib/Service/AppService.php
+++ b/lib/Service/AppService.php
@@ -603,6 +603,11 @@ class AppService
             $isEnforced = FALSE;
         }
 
+        # An app use flow ... let it do the job!
+        if (preg_match ("/^\/index.php\/login\/flow/",$_SERVER['PHP_SELF'])) {
+            $isEnforced = FALSE;
+        }
+
         return $isEnforced;
     }
 


### PR DESCRIPTION
Don't force authentication if an app use flow even if cas_force_login is true
Authentication is still forced after
It solve https://github.com/felixrupp/user_cas/issues/69

Regards,
Vincent