### PR TITLE
Raise Nextcloud version to 23

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,7 +30,7 @@
 
     <dependencies>
         <owncloud min-version="10.0" max-version="10.6"/>
-        <nextcloud min-version="14" max-version="20"/>
+        <nextcloud min-version="14" max-version="21"/>
     </dependencies>
 
     <commands>


### PR DESCRIPTION
I've just tested release 1.9.0 against nextcloud 21 and managed to login via CAS. Will do more testing, but at first sight it looks good !