### PR TITLE
Don't pass NULL to setcookie(,,*), use 0 instead.

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -56,18 +56,18 @@ if (\OCP\App::isEnabled($c->getAppName()) && !\OC::$CLI) {
                 $c->query('UserHooks')->register();
 
                 // URL params and redirect_url cookie
-                setcookie("user_cas_enforce_authentication", "0", null, '/');
+                setcookie("user_cas_enforce_authentication", "0", 0, '/');
                 $urlParams = '';
 
                 if (isset($_REQUEST['redirect_url'])) {
 
                     $urlParams = $_REQUEST['redirect_url'];
                     // Save the redirect_rul to a cookie
-                    $cookie = setcookie("user_cas_redirect_url", "$urlParams", null, '/');
+                    $cookie = setcookie("user_cas_redirect_url", "$urlParams", 0, '/');
                 }/*
                 else {
 
-                    setcookie("user_cas_redirect_url", '/', null, '/');
+                    setcookie("user_cas_redirect_url", '/', 0, '/');
                 }*/
 
                 // Register alternative LogIn
@@ -88,7 +88,7 @@ if (\OCP\App::isEnabled($c->getAppName()) && !\OC::$CLI) {
                     $loggingService = $c->query("LoggingService");
 
                     $loggingService->write(LoggingService::DEBUG, 'Enforce Authentication was: ' . $isEnforced);
-                    setcookie("user_cas_enforce_authentication", '1', null, '/');
+                    setcookie("user_cas_enforce_authentication", '1', 0, '/');
 
                     // Initialize app
                     if (!$appService->isCasInitialized()) {
@@ -101,7 +101,7 @@ if (\OCP\App::isEnabled($c->getAppName()) && !\OC::$CLI) {
 
                             $loggingService->write(LoggingService::DEBUG, 'Enforce Authentication was on and phpCAS is not authenticated. Redirecting to CAS Server.');
 
-                            $cookie = setcookie("user_cas_redirect_url", urlencode($requestUri), null, '/');
+                            $cookie = setcookie("user_cas_redirect_url", urlencode($requestUri), 0, '/');
 
                             header("Location: " . $appService->linkToRouteAbsolute($c->getAppName() . '.authentication.casLogin'));
                             die();

--- a/lib/Controller/AuthenticationController.php
+++ b/lib/Controller/AuthenticationController.php
@@ -165,7 +165,7 @@ class AuthenticationController extends Controller
                         $this->loggingService->write(\OCA\UserCas\Service\LoggingService::DEBUG, "phpCAS user has been authenticated against owncloud.");
 
                         # Reset cookie
-                        setcookie("user_cas_redirect_url", '/', null, '/');
+                        setcookie("user_cas_redirect_url", '/', 0, '/');
 
                         return new RedirectResponse($location);
                     } else { # Not authenticated against owncloud
@@ -191,7 +191,7 @@ class AuthenticationController extends Controller
             $this->loggingService->write(\OCA\UserCas\Service\LoggingService::DEBUG, "phpCAS user is already authenticated against owncloud.");
 
             # Reset cookie
-            setcookie("user_cas_redirect_url", '/', null, '/');
+            setcookie("user_cas_redirect_url", '/', 0, '/');
 
             return new RedirectResponse($location);
         }

--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -404,7 +404,7 @@ class UserHooks
             $this->loggingService->write(\OCA\UserCas\Service\LoggingService::DEBUG, 'phpCAS logging out.');
 
             # Reset cookie
-            setcookie("user_cas_redirect_url", '/', null, '/');
+            setcookie("user_cas_redirect_url", '/', 0, '/');
 
             \phpCAS::logout(array("service" => $this->appService->getAbsoluteURL('/')));
 


### PR DESCRIPTION
> Deprecated: setcookie(): Passing null to parameter #3 ($expires_or_options) of type array|int is deprecated in ***.

See https://3v4l.org/g1SUa

Since PHP 8.0, the type is `array|int`.